### PR TITLE
wip: testing dynamic import stuff to standardise the component page

### DIFF
--- a/docs/components/badge/index.md
+++ b/docs/components/badge/index.md
@@ -1,14 +1,12 @@
 <script setup>
-  import Vue from './vue.md';
-  import Elements from './elements.md';
-  import React from './react.md';
-  import Android from './android.md';
-  import iOS from './ios.md';
   import data from './data.json';
-  import { mapFrameworkStatuses } from '../utils.js';
+  import { mapFrameworkStatuses, useFrameworkDocs } from '../utils.js';
+
+  // Get the dynamically imported markdown components
+  const { vueDoc, reactDoc, elementsDoc, androidDoc, iosDoc } = useFrameworkDocs(data);
 </script>
 
-# Badge
+# {{ data.title }}
 
 {{ data.description }}
 
@@ -26,20 +24,23 @@
 
 ## Frameworks
 
-<tabs-content> 
-  <template #react>
-    <react />
-  </template>
-  <template #vue>
-    <vue />
-  </template>
-  <template #elements>
-    <elements />
-  </template>
-  <template #android>
-    <android />
-  </template>
-    <template #iOS>
-    <iOS />
-  </template>
-</tabs-content>
+<!-- Use keep-alive to cache components and avoid blinking -->
+<keep-alive>
+  <tabs-content>
+    <template #react>
+      <component :is="reactDoc" v-if="reactDoc" />
+    </template>
+    <template #vue>
+      <component :is="vueDoc" v-if="vueDoc" />
+    </template>
+    <template #elements>
+      <component :is="elementsDoc" v-if="elementsDoc" />
+    </template>
+    <template #android>
+      <component :is="androidDoc" v-if="androidDoc" />
+    </template>
+    <template #ios>
+      <component :is="iosDoc" v-if="iosDoc" />
+    </template>
+  </tabs-content>
+</keep-alive>

--- a/docs/components/utils.js
+++ b/docs/components/utils.js
@@ -4,3 +4,35 @@ export const mapFrameworkStatuses = (data) => data.reduce((acc, framework) => {
   }
   return acc;
 }, {});
+
+
+// Create dynamic imports based on framework names in data.json
+
+import { defineAsyncComponent } from 'vue';
+
+// Create dynamic imports based on framework names
+const loadMarkdownComponent = (frameworkName) => {
+  return defineAsyncComponent({
+    loader: () => import(`./${frameworkName.toLowerCase()}.md`),
+  });
+};
+
+// Load the framework docs based on the provided data
+export const useFrameworkDocs = (data) => {
+  const frameworkdoc = {};
+  data.frameworks.forEach((framework) => {
+    if (framework.status === 'released') {
+      const docName = framework.name.toLowerCase();
+      frameworkdoc[docName] = loadMarkdownComponent(docName);
+    }
+  });
+
+  // Return the docs for the relevant frameworks
+  return {
+    vueDoc: frameworkdoc['vue'],
+    reactDoc: frameworkdoc['react'],
+    elementsDoc: frameworkdoc['elements'],
+    androidDoc: frameworkdoc['android'],
+    iosDoc: frameworkdoc['ios'],
+  };
+};


### PR DESCRIPTION
Because of the cleanup tasks to get new content into prod asap, I removed this from the component pages because of its experimental nature.  Adding it as a pr because i dont know what to do with it. can be deleted if we dont care, its ment as a reference i guess :D 

I wanted to see if I could have a common setup for all the component pages, so they work dynamicaly instead of having to hardcode and maintain all the import stuff, i started on the stuff used in the tabsbar where you select framework. 

Problem I was trying to solve:      import Vue from './vue.md' does not fail gracefully if that file does not excist. (If it did we could just have all the imports and ignore the ones that are not excisting. but ideally we should be able to just add a [framework].md file and it dynamically gets picked up)

Solve1:    Lots of empty [framework].md files, so they always exist, not great, works build-time which is great.

Solve2:   Useframeworkdocs function , this uses data.json to import .md files based on the frameworks array. (thats the changes in this pr in the utils.js)   This sorta works, if we add a md file it gets picked up and the tab for it appears dynamically. This solve is async, unsure if that creates potential issues if there is a live component example inside one of those fetched files(?), I think the dynamic generated path might have become broken when I did the cleanup and moved the script to utils.js (The reference  to the md files is now relative to the utils.json i guess)

Solve3:  Chatgpt suggests setting up something to preprocess this before vitepress does its thing, sounds complicated.
 


 