### PR TITLE
fix: rename warp-portal-poc do docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# warp-portal-poc
-
-This project is an attempt to create a proof of concept of a complete Warp Design System documentation site.
+# Warp Docs
 
 ## Development
 
 ### Install dependencies
 Run `pnpm install`.
 
-### Run the app
+### Run the docs
 
-Run `pnpm docs:dev` to run the app locally.
+Start the development server, with hot reloading:
+
+```bash
+pnpm docs:dev
+```

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -7,7 +7,7 @@ import { supported as supportedClasses } from '../supported.js';
 import markdownItContainer from 'markdown-it-container';
 import svgLoader from 'vite-svg-loader'; // Import the svg loader
 
-const base = '/warp-portal-poc';
+const base = '/docs';
 
 const pdColorClasses = ['blue', 'cyan', 'fuchsia', 'indigo', 'pink', 'purple', 'sky', 'violet'].reduce(
   (colorResult, color) => [
@@ -187,7 +187,7 @@ export default defineConfig({
   themeConfig: {
     lastUpdated: true, // Add this to show the last updated timestamp
     editLink: {
-      pattern: 'https://github.com/warp-ds/warp-portal-poc/edit/main/docs/:path' // Edit link for GitHub
+      pattern: 'https://github.com/warp-ds/docs/edit/main/docs/:path' // Edit link for GitHub
     },
     search: { provider: 'local' },
     logo: '/warp-logo-small.svg',

--- a/docs/blog/posts.data.js
+++ b/docs/blog/posts.data.js
@@ -1,6 +1,6 @@
 import { createContentLoader } from "vitepress";
 
-const base = '/warp-portal-poc';
+const base = '/docs';
 
 export default createContentLoader("/blog/posts/**/*.md", {
   includeSrc: true, // include raw markdown source?

--- a/docs/blog/posts/2023/icons-v130.md
+++ b/docs/blog/posts/2023/icons-v130.md
@@ -51,4 +51,4 @@ We have added new icons :tada: All requests up until week 45 should have been ha
   </li>
 </ul>
 
-You can see all available icons in our documentation [here](https://warp-ds.github.io/warp-portal-poc/components/icons/).
+You can see all available icons in our documentation [here](https://warp-ds.github.io/docs/components/icons/).

--- a/docs/blog/posts/2023/icons-v140.md
+++ b/docs/blog/posts/2023/icons-v140.md
@@ -53,4 +53,4 @@ We have added new icons :tada: All requests up until Dec 7th should have been ha
   </li>
 </ul>
 
-You can see all available icons in our documentation [here](https://warp-ds.github.io/warp-portal-poc/components/icons/).
+You can see all available icons in our documentation [here](https://warp-ds.github.io/docs/components/icons/).

--- a/docs/blog/posts/2024/android-0.0.27.md
+++ b/docs/blog/posts/2024/android-0.0.27.md
@@ -24,7 +24,7 @@ fun WarpCheckbox(
 )
 ```
 
-* Checkbox component now available in Warp, ([more info here](https://warp-ds.github.io/warp-portal-poc/components/checkbox/))
+* Checkbox component now available in Warp, ([more info here](https://warp-ds.github.io/docs/components/checkbox/))
 * Supports Finn, Tori & DBA
 * Supports legacy layouts written in XML
 

--- a/docs/blog/posts/2024/icons-v2.md
+++ b/docs/blog/posts/2024/icons-v2.md
@@ -329,7 +329,7 @@ In addition to renamed icons, we've added missing 16px versions of functional ic
   </li>
 </ul>
 
-You can see all available icons in our documentation [here](https://warp-ds.github.io/warp-portal-poc/components/icons/).
+You can see all available icons in our documentation [here](https://warp-ds.github.io/docs/components/icons/).
 
 <style scoped>
   .post-blog-table p {

--- a/docs/components/ComponentOverview.vue
+++ b/docs/components/ComponentOverview.vue
@@ -39,7 +39,7 @@ const componentData = Object.keys(components).map(path => {
 
   return {
     ...validateComponentData(rawData, folderPath),  // Validate each component's data
-    href: `/warp-portal-poc/components/${folderPath}`
+    href: `/docs/components/${folderPath}`
   };
 });
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ const cardData = {
       <p class="tagline">Design, build and ship coherent experience with WARP</p>
       <div class="actions">
         <div class="action">
-          <a class="vp-font-size-4 brand" href="/warp-portal-poc/get-started">Get Started →</a>
+          <a class="vp-font-size-4 brand" href="/docs/get-started">Get Started →</a>
         </div>
       </div>
     </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ const cardData = {
       <p class="tagline">Design, build and ship coherent experience with WARP</p>
       <div class="actions">
         <div class="action">
-          <a class="vp-font-size-4 brand" href="/docs/get-started">Get Started →</a>
+          <a class="vp-font-size-4 brand" href="get-started">Get Started →</a>
         </div>
       </div>
     </div>
@@ -110,7 +110,7 @@ const cardData = {
   <div class="banner-column">
     <h2 class="banner-title">Collaborate</h2>
     <p class="banner-content">Contributing to the WARP design system, requesting new components or adjustments to existing ones.</p>
-    <a :href="`${baseUrl}collaborate/request-new-component`" class="banner-link collaborate">
+    <a href="collaborate/request-new-component" class="banner-link collaborate">
       Collaborate with us
       <span class="vpi-arrow-right link-text-icon"></span>
     </a>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "warp-portal-poc",
+  "name": "docs",
   "version": "1.0.0",
-  "description": "Proof of concept of a complete documentation of the Warp Design System",
+  "description": "Documentation of the Warp Design System",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Fixes [WARP-609](https://nmp-jira.atlassian.net/browse/WARP-609)
The docs will now be deployed to [warp-ds/docs](https://warp-ds.github.io/docs).