### PR TITLE
chore(scripts): drop docs: prefix in package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
-    "docs:serve": "vitepress serve docs"
+    "dev": "vitepress dev docs",
+    "build": "vitepress build docs",
+    "serve": "vitepress serve docs"
   },
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
We don't need the `docs:` prefix when docs is the only thing we work with here.