### PR TITLE
chore: update slack channel name to smp-warp-design-system

### DIFF
--- a/docs/blog/posts/2024/warp-2-0.md
+++ b/docs/blog/posts/2024/warp-2-0.md
@@ -131,5 +131,5 @@ Make sure to also align the `resets.css` and `components.css` stylesheets to v2:
 ## What's next
 
 Since most packages are in the next branch, expect some bugs.
-Report any issues on the [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV) Slack channel.
+Report any issues on the [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV) Slack channel.
 We’re here to help!

--- a/docs/collaborate/request-component-changes/index.md
+++ b/docs/collaborate/request-component-changes/index.md
@@ -12,4 +12,4 @@ Things to consider when requesting component changes:
 - If no, is this something that benefits more than just your team?
 - What variants and use cases do you see?
 
-Reach out to the Warp team on slack [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) with your request, and we will help you.
+Reach out to the Warp team on slack [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) with your request, and we will help you.

--- a/docs/collaborate/request-new-component/index.md
+++ b/docs/collaborate/request-new-component/index.md
@@ -12,7 +12,7 @@ Things to consider when requesting a new component:
 - If no, is this something that benefits more than just your team?
 - What variants and use cases do you see?
 
-Reach out to the Warp team on Slack: [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) with your request, and we will help you.
+Reach out to the Warp team on Slack: [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) with your request, and we will help you.
 
 ## Prioritisation of component requests
 We prioritise the requests based on:

--- a/docs/components/ComponentQuestions.md
+++ b/docs/components/ComponentQuestions.md
@@ -1,2 +1,2 @@
 ### Questions?
-Feel free to ask any questions on usage in the Warp DS Slack channel: [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV)
+Feel free to ask any questions on usage in the Warp DS Slack channel: [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV)

--- a/docs/components/icons/index.md
+++ b/docs/components/icons/index.md
@@ -52,7 +52,7 @@ Warp icon library contains of ~300 icons in sizes 16px, 24px and 32px. It's base
 <components-status v-bind="mapFrameworkStatuses(data.frameworks)" />
 
 ## Need new icons?
-If you need a new icon or adjustments to an existing one, please make a request in #nmp-warp-design-system in Slack.
+If you need a new icon or adjustments to an existing one, please make a request in #smp-warp-design-system in Slack.
 
 
 ## Usage

--- a/docs/foundations/css-classes/divide-style.md
+++ b/docs/foundations/css-classes/divide-style.md
@@ -5,7 +5,7 @@
 Utilities for controlling the border style between elements.
 
 ::: danger Unsupported
-This functionality is not yet supported! If you need this, reach out to us on [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/css-classes/font-variant-numeric.md
+++ b/docs/foundations/css-classes/font-variant-numeric.md
@@ -9,7 +9,7 @@ Utilities for controlling the variant of numbers.
 <qr-table />
 
 ::: warning `normal-nums` not yet supported
-This class is not yet supported! If you need this, reach out to us on [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This class is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Basic usage

--- a/docs/foundations/css-classes/max-width.md
+++ b/docs/foundations/css-classes/max-width.md
@@ -24,7 +24,7 @@ Utilities for setting the maximum width of an element.
 > `{breakpoint}`: `sm`, `md`, `lg`
 
 ::: warning `max-w-{breakpoint}` not yet supported
-This functionality is not yet supported! If you need this, reach out to us on [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Basic usage

--- a/docs/foundations/css-classes/scroll-snap-align.md
+++ b/docs/foundations/css-classes/scroll-snap-align.md
@@ -5,7 +5,7 @@
 Utilities for controlling the scroll offset around items in a snap container.
 
 ::: danger Unsupported
-This functionality is not yet supported! If you need this, reach out to us on [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/css-classes/scroll-snap-stop.md
+++ b/docs/foundations/css-classes/scroll-snap-stop.md
@@ -5,7 +5,7 @@
 Utilities for controlling whether you can skip past possible snap positions.
 
 ::: danger Unsupported
-This functionality is not yet supported! If you need this, reach out to us on [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/css-classes/scroll-snap-type.md
+++ b/docs/foundations/css-classes/scroll-snap-type.md
@@ -4,7 +4,7 @@
 Utilities for controlling how strictly snap points are enforced in a snap container.
 
 ::: danger Unsupported
-This functionality is not yet supported! If you need this, reach out to us on [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/css-classes/will-change.md
+++ b/docs/foundations/css-classes/will-change.md
@@ -5,7 +5,7 @@
 Utilities for optimizing upcoming animations of elements that are expected to change.
 
 ::: warning Partially Unsupported
-Some of this functionality is not yet supported! If you need this, reach out to us on [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+Some of this functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/data-visualization/getting-started/index.md
+++ b/docs/foundations/data-visualization/getting-started/index.md
@@ -65,7 +65,7 @@ We have not (yet) decided on a recommended charting library. Make sure to check 
 
 ## How do you provide feedback or get help?
 
-Don’t hesitate to reach out to the design system team [on Slack (#nmp-warp-design-system)](https://sch-chat.slack.com/archives/C04P0GYTHPV) if you have any feedback or questions.
+Don’t hesitate to reach out to the design system team [on Slack (#smp-warp-design-system)](https://sch-chat.slack.com/archives/C04P0GYTHPV) if you have any feedback or questions.
 
 [Jon Olav](https://sch-chat.slack.com/team/U03KEH3V4) is an information designer working across verticals and brands in NMP, and can help you with:
 

--- a/docs/get-started/developers/android/index.md
+++ b/docs/get-started/developers/android/index.md
@@ -3,7 +3,7 @@
 
 This page describes how to get started building an application with Warp components.
 
-If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
+If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
 
 
 ## 1. Integrate Warp

--- a/docs/get-started/developers/ios/index.md
+++ b/docs/get-started/developers/ios/index.md
@@ -3,7 +3,7 @@
 
 This page describes how to get started building an application with Warp components.
 
-If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
+If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
 
 
 ## 1. Integrate Warp

--- a/docs/get-started/developers/web/index.md
+++ b/docs/get-started/developers/web/index.md
@@ -14,7 +14,7 @@ Only the used utilities are shipped to your app, ensuring speed and efficiency i
 
 If you are migrating from Fabric to Warp, please visit the [Migration page](./migrate-from-fabric/).
 
-If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
+If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
 
 ## 1. Integrate with UnoCSS and Warp
 

--- a/docs/help/report-bugs/index.md
+++ b/docs/help/report-bugs/index.md
@@ -4,4 +4,4 @@ Guidance on reporting bugs and errors.
 ## Slack
 If you encounter a bug or an error, please reach out on Slack and we will look into it. 
 
-[#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV)
+[#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV)

--- a/docs/help/support/index.md
+++ b/docs/help/support/index.md
@@ -4,7 +4,7 @@ Support guidance from the WARP Team.
 ## Slack
 We are always available in our slack channel and we really want that to be a blossoming place for all kinds of community driven discussions where anyone should be able to ask questions and engage in discussions about how to take our design system to the next level.
 
-[#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV)
+[#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV)
 
 ## Team 
 <div style="display:flex; gap:8px;">

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ const cardData = {
       <p class="banner-content">Need help or support? The best way to get in touch with the team is through Slack.</p>
       <div class="slack-section">
         <img src="/slack-icon.svg" alt="Slack icon" width="24px" class="slack-icon"/>
-        <a href="https://sch-chat.slack.com/archives/C04P0GYTHPV" target="_blank" class="banner-link">#nmp-warp-design-system</a>
+        <a href="https://sch-chat.slack.com/archives/C04P0GYTHPV" target="_blank" class="banner-link">#smp-warp-design-system</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Our slack channel was renamed so it should be reflected in our docs to avoid confusion. The Slack ID stays the same.