### PR TITLE
Fix: broken links

### DIFF
--- a/docs/foundations/brands/index.md
+++ b/docs/foundations/brands/index.md
@@ -9,8 +9,8 @@ An overview with links to our brand guidelines.
 | Brand    | Link                                                                                            |
 | -------- | ----------------------------------------------------------------------------------------------- |
 | Bilbasen | Does not exist                                                                                  |
-| Blocket  | [Designmanual.pdf](https://drive.google.com/file/d/1qLoyCEaSZ4bBUOd5IGrbDpUHBKlb81cD/view)      |
-| DBA      | [Designmanual.pdf](https://drive.google.com/file/d/1eSLUXIK3mapZaipWgy5oicOD0Mq1P2Sw/view)      |
+| Blocket  | [Designmanual.pdf](https://drive.google.com/file/d/1eSLUXIK3mapZaipWgy5oicOD0Mq1P2Sw/view)      |
+| DBA      | [Designmanual.pdf](https://drive.google.com/file/d/1qLoyCEaSZ4bBUOd5IGrbDpUHBKlb81cD/view)      |
 | FINN     | [Designmanual.pdf](https://drive.google.com/file/d/1MdBcQfseDJTOeSINDP8hmCiDGMNNSY0P/view)      |
 | Oikotie  | Does not exist                                                                                  |
-| Tori     | [Brand guidesliens.pdf](https://drive.google.com/file/d/1MdBcQfseDJTOeSINDP8hmCiDGMNNSY0P/view) |
+| Tori     | [Brand guidesliens.pdf](https://drive.google.com/file/d/1uwoVGWAbl2-xf7ioMHM_HuA5CTr85l4B/view) |


### PR DESCRIPTION
Fix broken links to brand documentation

Related slack issue:
[https://sch-chat.slack.com/archives/C04P0GYTHPV/p1736846986390319](https://www.google.com/url?q=https://sch-chat.slack.com/archives/C04P0GYTHPV/p1736846986390319&sa=D&source=calendar&ust=1738060595187478&usg=AOvVaw0ATA9f5fT1ZTZxOp9GVNJe)