### PR TITLE
Bump icons, update What's new

### DIFF
--- a/docs/blog/posts/2025/icons-v260.md
+++ b/docs/blog/posts/2025/icons-v260.md
@@ -1,0 +1,28 @@
+---
+title: "@warp-ds/icons v2.6.0"
+date: 2025-04-09
+---
+
+## New icons added, plus some maintenance!
+
+We have added **5 new icons** :tada:, in 3 sizes (16, 24 and 32px)!
+
+List of the newcomers, including the requested drag-dots icon:
+
+<ul>
+<li>CarLeft</li>
+<li>CarRight</li>
+<li>PlaneLand</li>
+<li>PlaneTakeOff</li>
+<li>DragDots</li>
+</ul>
+
+<br />
+Additionally, these changes have been made on the code side of the repository:
+
+- lingui files have been moved from individual icon directories to a separate locales directory: this is not a breaking change for users.
+- added inline JSDoc typings to icon React components for improved autocomplete and prop hints in JavaScript editors — via user contribution! ⭐
+
+<br />
+
+You can see all available icons in our documentation [here](https://warp-ds.github.io/docs/components/icons/).

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@unocss/core": "0.65.4",
     "@vueuse/core": "10.11.0",
     "@warp-ds/css": "2.1.1",
-    "@warp-ds/icons": "2.5.0",
+    "@warp-ds/icons": "2.6.0",
     "@warp-ds/preset-docs": "0.0.16",
     "@warp-ds/react": "2.1.0",
     "@warp-ds/uno": "2.1.0",


### PR DESCRIPTION
Bumbs icons to 2.6.0, adding 5 new icons:

- car-left
- car-right
- plane-landing
- plane-take-off
- drag-dots

Add "What's new for icons"