### PR TITLE
Remove line on title2

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -155,7 +155,7 @@ html.dark body {
 }
 /* make the border stand out a touch more */
 .vp-doc h2 {
-  border-top-width: 2px;
+  border-top-width: 0px;
 }
 /* wasn't enough breathing room here, add some more */
 .vp-doc h4 {


### PR DESCRIPTION
Just sets up the titles rendered by markup to work the same as in figma, only different I could see was the devider line in the H2

