### PR TITLE
Fix an import statement for elements icons

### DIFF
--- a/docs/components/icons/elements.md
+++ b/docs/components/icons/elements.md
@@ -2,7 +2,7 @@
 Import Elements icons individually to optimize your JS bundle size by adding only the icons you need:
 
 ```js
-import "@warp-ds/icons/elements/components/alert-16";
+import "@warp-ds/icons/elements/alert-16";
 ```
 
 Don't import icons directly from the `@warp-ds/icons/elements` package, since this will add every Warp icon, and bloat your bundle.


### PR DESCRIPTION
Couldn't find icons at `elements/components/<icon>`, but they were there on `elements/<icon>`.