### PR TITLE
Add `duration` option to `Toast` component (WARP-967)

### DIFF
--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -4156,6 +4156,12 @@ export const iOS = {
     ],
   ],
     props: [
+      [
+        'duration',
+        'Warp.Toast.Duration.short <br /> Warp.Toast.Duration.long <br /> Warp.Toast.Duration.custom(interval:) ',
+        '.short',
+        'Duration the Toast is shown'
+      ],
     ],
   },
   Tooltip: {

--- a/docs/components/toast/ios.md
+++ b/docs/components/toast/ios.md
@@ -7,6 +7,7 @@ Warp.Toast(
     style: Warp.ToastStyle,
     title: String,
     toastEdge: Warp.ToastEdge,
+    duration: Duration = .short,
     isPresented: Binding<Bool>
 )
 ```
@@ -18,6 +19,7 @@ Warp.Toast(
     style: .success,
     title: "This is a toast",
     toastEdge: .top,
+    duration: .short,
     isPresented: .constant(true)
 )
 
@@ -25,6 +27,7 @@ Warp.Toast(
     style: .success,
     title: "This is a toast",
     toastEdge: .top,
+    duration: .short,
     isPresented: .constant(true)
 )
 ```
@@ -46,6 +49,23 @@ enum Warp.ToastStyle {
 enum Warp.ToastEdge {
     case top
     case bottom
+}
+```
+
+## Auto dismiss duration option - default: short
+
+```swift example
+enum Warp.Toast.Duration {
+    /// Short duration, typically used for quick feedback messages.
+    /// Default is 5 seconds.
+    case short
+    /// Long duration, typically used for more significant messages that require user attention.
+    /// Default is 10 seconds.
+    case long
+    /// Infinite duration, typically used for messages that require user interaction to dismiss.
+    case infinite
+    /// Custom duration time interval
+    case custom(interval: TimeInterval)
 }
 ```
 


### PR DESCRIPTION
Add missing `duration` for auto dismissing toast view on iOS