### PR TITLE
Replace old Slack channel name with new one

### DIFF
--- a/docs/collaborate/request-component-changes/index.md
+++ b/docs/collaborate/request-component-changes/index.md
@@ -12,4 +12,4 @@ Things to consider when requesting component changes:
 - If no, is this something that benefits more than just your team?
 - What variants and use cases do you see?
 
-Reach out to the Warp team on slack [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) with your request, and we will help you.
+Reach out to the Warp team on slack [#warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) with your request, and we will help you.

--- a/docs/collaborate/request-new-component/index.md
+++ b/docs/collaborate/request-new-component/index.md
@@ -12,7 +12,7 @@ Things to consider when requesting a new component:
 - If no, is this something that benefits more than just your team?
 - What variants and use cases do you see?
 
-Reach out to the Warp team on Slack: [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) with your request, and we will help you.
+Reach out to the Warp team on Slack: [#warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) with your request, and we will help you.
 
 ## Prioritisation of component requests
 We prioritise the requests based on:

--- a/docs/foundations/accessibility/index.md
+++ b/docs/foundations/accessibility/index.md
@@ -10,7 +10,7 @@ The Vend a11y team has a playbook where you'll find essential tips and tools to 
 [Accessibility Playbook](https://zeroheight.com/23ed9d143/p/504116-accessibility-playbook)
 
 **Slack support**<br>
-[#smp-accessibility](https://sch-chat.slack.com/archives/C06MRNFR8)
+[#vend-accessibility](https://sch-chat.slack.com/archives/C06MRNFR8)
 
 ## Figma Plugins
 

--- a/docs/foundations/css-classes/divide-style.md
+++ b/docs/foundations/css-classes/divide-style.md
@@ -5,7 +5,7 @@
 Utilities for controlling the border style between elements.
 
 ::: danger Unsupported
-This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/css-classes/font-variant-numeric.md
+++ b/docs/foundations/css-classes/font-variant-numeric.md
@@ -9,7 +9,7 @@ Utilities for controlling the variant of numbers.
 <qr-table />
 
 ::: warning `normal-nums` not yet supported
-This class is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This class is not yet supported! If you need this, reach out to us on [#warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Basic usage

--- a/docs/foundations/css-classes/max-width.md
+++ b/docs/foundations/css-classes/max-width.md
@@ -24,7 +24,7 @@ Utilities for setting the maximum width of an element.
 > `{breakpoint}`: `sm`, `md`, `lg`
 
 ::: warning `max-w-{breakpoint}` not yet supported
-This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Basic usage

--- a/docs/foundations/css-classes/scroll-snap-align.md
+++ b/docs/foundations/css-classes/scroll-snap-align.md
@@ -5,7 +5,7 @@
 Utilities for controlling the scroll offset around items in a snap container.
 
 ::: danger Unsupported
-This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/css-classes/scroll-snap-stop.md
+++ b/docs/foundations/css-classes/scroll-snap-stop.md
@@ -5,7 +5,7 @@
 Utilities for controlling whether you can skip past possible snap positions.
 
 ::: danger Unsupported
-This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/css-classes/scroll-snap-type.md
+++ b/docs/foundations/css-classes/scroll-snap-type.md
@@ -4,7 +4,7 @@
 Utilities for controlling how strictly snap points are enforced in a snap container.
 
 ::: danger Unsupported
-This functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+This functionality is not yet supported! If you need this, reach out to us on [#warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/css-classes/will-change.md
+++ b/docs/foundations/css-classes/will-change.md
@@ -5,7 +5,7 @@
 Utilities for optimizing upcoming animations of elements that are expected to change.
 
 ::: warning Partially Unsupported
-Some of this functionality is not yet supported! If you need this, reach out to us on [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
+Some of this functionality is not yet supported! If you need this, reach out to us on [#warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV).
 :::
 
 ## Quick reference

--- a/docs/foundations/data-visualization/introduction/index.md
+++ b/docs/foundations/data-visualization/introduction/index.md
@@ -147,4 +147,4 @@ It seems that the goal of this visualization is to explain a specific message, r
 
 ## How do you provide feedback or get help?
 
-Don’t hesitate to reach out to the design system team [on Slack (#smp-warp-design-system)](https://sch-chat.slack.com/archives/C04P0GYTHPV) if you have any feedback or questions.
+Don’t hesitate to reach out to the design system team [on Slack (#warp-design-system)](https://sch-chat.slack.com/archives/C04P0GYTHPV) if you have any feedback or questions.

--- a/docs/get-started/developers/android/index.md
+++ b/docs/get-started/developers/android/index.md
@@ -3,7 +3,7 @@
 
 This page describes how to get started building an application with Warp components.
 
-If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
+If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
 
 
 ## 1. Integrate Warp

--- a/docs/get-started/developers/ios/index.md
+++ b/docs/get-started/developers/ios/index.md
@@ -3,7 +3,7 @@
 
 This page describes how to get started building an application with Warp components.
 
-If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
+If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
 
 
 ## 1. Integrate Warp

--- a/docs/get-started/developers/web/index.md
+++ b/docs/get-started/developers/web/index.md
@@ -14,7 +14,7 @@ Only the used utilities are shipped to your app, ensuring speed and efficiency i
 
 If you are migrating from Fabric to Warp, please visit the [Migration page](./migrate-from-fabric/).
 
-If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#smp-warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
+If you have any questions or need clarification, please don't hesitate to reach out to the Warp team on the [#warp-design-system](https://sch-chat.slack.com/archives/C04NF2K46LB) channel on Slack!
 
 ## 1. Integrate with UnoCSS and Warp
 

--- a/docs/get-started/developers/web/react.md
+++ b/docs/get-started/developers/web/react.md
@@ -25,7 +25,7 @@ import { Box } from '@warp-ds/react/components/box'
 ```
 
 You can find the specific import statement to import each component on that
-component's documentation page. For example, here's the [button page](/components/button/)
+component's documentation page. For example, here's the [button page](/components/button/).
 
 
 ## TypeScript support

--- a/docs/get-started/developers/web/vue.md
+++ b/docs/get-started/developers/web/vue.md
@@ -39,7 +39,7 @@ import { wButton } from '@warp-ds/vue/button'
 This code is bringing in the Button component itself, rather than an installer - this is denoted by the `w` prefix of the component. Some edge-case components may be available this way that don't make sense to globally install for everyone.
 
 You can find the specific import statement to import each component on that
-component's documentation page. For example, here's the [button page](/components/button/)
+component's documentation page. For example, here's the [button page](/components/button/).
 
 ## Eik support
 We publish `@warp-ds/vue` package to EIK cdn, eg:

--- a/docs/help/report-bugs/index.md
+++ b/docs/help/report-bugs/index.md
@@ -4,4 +4,4 @@ Guidance on reporting bugs and errors.
 ## Slack
 If you encounter a bug or an error, please reach out on Slack and we will look into it. 
 
-[#smp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV)
+[#warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV)

--- a/docs/help/support/index.md
+++ b/docs/help/support/index.md
@@ -38,7 +38,7 @@ const members = [
     title: 'Lead Android Developer',
   },
   {
-    avatar: "https://ca.slack-edge.com/T0356Q2CJ-U0266UPB5RU-a07e97493e28-72",
+    avatar: "https://ca.slack-edge.com/T0356Q2CJ-U09374BCZJ5-a43970e6c724-512",
     name: 'Łukasz Śliwa',
     title: 'Lead iOS Developer',
   },

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,7 +125,7 @@ const cardData = {
       <p class="banner-content">Need help or support? The best way to get in touch with the team is through Slack.</p>
       <div class="slack-section">
         <img src="/slack-icon.svg" alt="Slack icon" width="24px" class="slack-icon"/>
-        <a href="https://sch-chat.slack.com/archives/C04P0GYTHPV" target="_blank" class="banner-link">#smp-warp-design-system</a>
+        <a href="https://sch-chat.slack.com/archives/C04P0GYTHPV" target="_blank" class="banner-link">#warp-design-system</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Changes to Warp Portal:**
1. Replaced references to Warp's Slack channel from `#smp-warp-design-system` to `#warp-design-system`.
2. Replace reference to Accessibility Slack channel from `#smp-accessibility` to `#vend-accessibility`.
3. Changed Lukasz's profile photo to one from Slack.