### PR TITLE
Update docs for iOS Warp v. `0.0.65`

### DIFF
--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -4094,13 +4094,109 @@ export const iOS = {
         'step',
         'Double',
         '1.0',
-        'Step value for the slider'
+        'The increment by which the slider value should change.'
+      ],
+      [
+        'showTooltips',
+        'Bool',
+        'true',
+        'Whether to show tooltips above the thumbs.'
+      ],
+      [
+        'showRange',
+        'Bool',
+        'false',
+        'Whether to show min/max range indicators.'
+      ],
+      [
+        'enabled',
+        'Bool',
+        'true',
+        'Whether the slider is enabled or disabled.'
+      ],
+      [
+        'valueFormatter',
+        '(Double) -> String',
+        'nil',
+        'A closure that formats the displayed value. Defaults to a simple string conversion.'
       ],
       [
         'onEditingChanged',
         '((Double) -> Void)?',
         'nil',
-        'Completion handler to return the value when handle is dropped'
+        'A closure that is called when the slider\'s thumb is released, passing the final value as an argument.'
+      ],
+      [
+        'selectedItem',
+        'Binding<T> (where T: LosslessStringConvertible & Equatable)',
+        '—',
+        'For discrete sliders: a binding to the currently selected item from the list.'
+      ],
+      [
+        'items',
+        'Array<T> (where T: LosslessStringConvertible & Equatable)',
+        '—',
+        'For discrete sliders: an array of items to choose from.'
+      ],
+    ],
+  },
+  RangeSlider: {
+    required: [
+      [
+        'range',
+        'Binding<ClosedRange<Double>>',
+        '',
+        'A binding to the current selected range of the slider.'
+      ],
+      [
+        'bounds',
+        'ClosedRange<Double>',
+        '',
+        'The minimum and maximum values for the slider.'
+      ],
+    ],
+    props: [
+      [
+        'step',
+        'Double',
+        '1.0',
+        'The increment by which the slider value should change.'
+      ],
+      [
+        'showTooltips',
+        'Bool',
+        'true',
+        'Whether to show tooltips above the thumbs.'
+      ],
+      [
+        'showRange',
+        'Bool',
+        'false',
+        'Whether to show min/max range indicators.'
+      ],
+      [
+        'enabled',
+        'Bool',
+        'true',
+        'Whether the slider is enabled or disabled.'
+      ],
+      [
+        'selectedItems',
+        'Binding<[T]>',
+        '',
+        'For discrete sliders: a binding to the currently selected items from the list. T must conform to LosslessStringConvertible & Equatable.'
+      ],
+      [
+        'items',
+        'Array<T>',
+        '',
+        'For discrete sliders: an array of items to choose from. T must conform to LosslessStringConvertible & Equatable.'
+      ],
+      [
+        'valueFormat',
+        '(T) -> String',
+        'nil',
+        'For discrete sliders: a closure that formats the displayed value. Defaults to a simple string conversion.'
       ],
     ],
   },

--- a/docs/blog/posts/2025/ios-0.0.65.md
+++ b/docs/blog/posts/2025/ios-0.0.65.md
@@ -1,0 +1,137 @@
+---
+title: 'WARP iOS release v.0.0.65'
+date: 2025-10-07
+---
+
+Taxonomy icons & RangeSlider 
+---
+
+# Warp iOS release 0.0.65
+
+## 2025-10-07
+
+#### Slider component
+- Update visuals
+- Add possibility to select from predefined array of values
+
+```swift
+@State private var selectedItem = "Medium"
+let items = ["Small", "Medium", "Large"]
+Warp.Slider(selectedItem: $selectedItem, items: items)
+```
+
+#### RangeSlider component
+- New range slider component that allows for setting the minimum and maximum values with a defined step interval or by selecting from an array of discrete values.
+
+```swift
+// Example 1: RangeSlider with numeric range
+@State private var sliderRange = 30.0...100.0
+
+Warp.RangeSlider(
+    range: $sliderRange,
+    bounds: 0...100,
+)
+
+// Example 2: RangeSlider with discrete values
+@State private var selectedItems = ["Banana", "Date"]
+let items = ["Apple", "Banana", "Cherry", "Date", "Fig", "Grape"]
+
+Warp.RangeSlider(
+    selectedItems: $selectedItems,
+    items: items,
+)
+```
+
+#### Taxonomy icon changes 
+All taxonomy icons have now the same default size as regular icons - 24.dp x 24.dp
+
+Replaced icons:
+- **PlaneTakeOff** (uses existing icon — replacing taxonomy icon "Airplane")
+- **AirplaneBed** (new icon — replacing "AirplaneHotel")
+- **CabinHut** (uses existing icon — replacing "Cabin")
+- **CarPart** (new icon — replacing "CarPart")
+- **CarRent** (new icon — replacing "CarRent")
+- **Chair** (new icon — replacing "Chair")
+- **Guitar** (new icon — replacing "GuitarBat")
+- **Building** (uses existing icon — replacing "Hotel")
+- **IceSkater** (new icon — replacing "IceSkater")
+- **Briefcase** (new icon — replacing "Job")
+- **CarRight** (uses existing icon — replacing "Minivan")
+- **Motorcycle** (new icon — replacing "Motorcycle")
+- **AnimalPaw** (uses existing icon — replacing "Paw")
+- **PhoneCheck** (new icon — replacing "PhoneBadgeCheck")
+- **HouseModern** (uses existing icon — replacing "RealEstate")
+- **Boat** (uses existing icon — replacing "Sailboat")
+- **Shirt** (new icon — replacing "Shirt")
+- **Phone** (uses existing icon — replacing "Smartphone")
+- **Sofa** (new icon — replacing "Sofa")
+- **StoreFront** (new icon — replacing "StoreFront")
+- **Stroller** (new icon — replacing "Stroller")
+- **Drill** (new icon — replacing "Tools")
+- **Tractor** (uses existing icon — replacing "Tractor")
+- **Vase** (new icon — replacing "Vase")
+
+Removed identical icons:
+- **NorwegianMotor** (same as StarCheck)
+- **Sailing** (same as Boat)
+- **Plots** (same as BuildingPlot)
+- **CottagePlot** (same as BuildingPlot)
+- **Measure** (same as Ruler)
+- **BoatLength** (same as Ruler)
+- **Feedback** (same as Messages)
+- **Message** (same as Messages)
+- **ChatRequest** (same as Messages)
+- **NewAd** (same as CirclePlus)
+- **Krone** (same as Money)
+- **UserWoman** (same as User)
+- **CarKey** (same as Key)
+- **HouseCabin** (same as House)
+- **SearchFavorites** (same as Search)
+- **CarService** (same as Service/Wrench)
+- **CarEngine** (same as Engine)
+
+Renamed icons:
+- **Tractor** (before ArgiculturalMachine)
+- **Wrench** (before Service)
+- **GearManual** (before Manual)
+- **GearAutomatic** (before Automatic)
+- **WashingMachine** (before Laundry)
+- **Rocket** (before ProductBlink)
+- **X** (before Twitter)
+- **LotusFlower** (before Spa)
+- **Tree** (before Woods)
+- **Ticket** (before PlaneTicket)
+- **Megaphone** (before ProductNoAds)
+- **Paperclip** (before Attachment)
+- **Dumbbell** (before Fitness)
+- **Key** (before Keys)
+
+Updated visuals for existing icons:
+- **AnimalPaw**
+- **Lamp**
+- **Propeller**
+- **Tractor**
+- **Boat**
+- **Phone**
+- **PhoneScratched**
+- **PhoneUser**
+- **FrontWheelDrive**
+- **AllWheelDrive**
+- **BackWheelDrive**
+- **UserGroup**
+- **SmileyGood**
+- **SmileyHappy**
+- **PlaneTakeOff**
+- **PlaneLand**
+- **Diner**
+- **AirCon**
+- **HotelBed**
+
+
+#### New border-strong token
+Introducing new, darker border color (Gray 500)
+The affected components are:
+- **Checkbox**
+- **Radio**
+- **TextField**
+- **TextArea**

--- a/docs/components/broadcast/index.md
+++ b/docs/components/broadcast/index.md
@@ -28,7 +28,7 @@ frameworks:
 - name: Elements
   status: deprecated
 - name: iOS
-  status: released
+  status: deprecated
 ---
 # {{ $frontmatter.title }}
 {{ $frontmatter.description }}

--- a/docs/components/rangeslider/frameworks/ios.md
+++ b/docs/components/rangeslider/frameworks/ios.md
@@ -1,0 +1,65 @@
+### Syntax
+
+#### Using range
+
+```swift example
+Warp.RangeSlider(
+    range: Binding<ClosedRange<Double>>,
+    bounds: ClosedRange<Double>,
+    step: Double = 1.0,
+    showTooltips: Bool = true,
+    showRange: Bool = false,
+    enabled: Bool = true,
+)
+```
+
+**Example:**
+
+```swift example
+@State private var selectedRange: ClosedRange<Double> = 20.0...80.0
+
+Warp.RangeSlider(
+    range: $selectedRange,
+    bounds: 0.0...100.0,
+    step: 1.0
+)
+```
+
+#### Using array
+
+```swift example
+Warp.RangeSlider(
+    selectedItems: Binding<[ArrayElement]>,
+    items: [ArrayElement],
+    showTooltips: Bool = true,
+    showRange: Bool = false,
+    enabled: Bool = true,
+    valueFormat: ((ArrayElement) -> String)? = nil
+)
+```
+
+**Example:**
+
+```swift example
+@State private var selectedSizes: [String] = ["Medium", "Large"]
+let sizes = ["Small", "Medium", "Large"]
+
+Warp.RangeSlider(
+    selectedItems: $selectedSizes,
+    items: sizes
+)
+```
+
+### Legacy support
+
+By default all Warp components return a `SwiftUI View` but there is always a `UIKit UIView` available to use also.
+
+```swift example
+Warp.RangeSlider(
+    range: $selectedRange,
+    bounds: 0.0...100.0,
+    step: 1.0
+).uiView
+```
+
+<api-table type=iOS component="RangeSlider" />

--- a/docs/components/rangeslider/index.md
+++ b/docs/components/rangeslider/index.md
@@ -29,6 +29,8 @@ frameworks:
   status: beta
 - name: Android
   status: released
+- name: iOS
+  status: released
 ---
 
 # {{ $frontmatter.title }}

--- a/docs/components/slider/frameworks/ios.md
+++ b/docs/components/slider/frameworks/ios.md
@@ -1,10 +1,15 @@
 ### Syntax
 
+#### Using range
+
 ```swift example
 Warp.Slider(
     value: Binding<Double>,
     range: ClosedRange<Double>,
     step: Double = 1.0,
+    showTooltips: Bool = true,
+    showRange: Bool = false,
+    enabled: Bool = true,
     onEditingChanged: ((Double) -> Void)? = nil
 )
 ```
@@ -15,6 +20,25 @@ Warp.Slider(
     range: 0.0...100.0,
     step: 1.0
 )
+```
+
+#### Using array
+
+```swift example
+Warp.Slider(
+    selectedItem: Binding<ArrayElement>,
+    items: Array<ArrayElement>,
+    showTooltips: Bool = true,
+    showRange: Bool = false,
+    enabled: Bool = true,
+    valueFormat: ((ArrayElement) -> String)? = nil
+)
+```
+
+```swift example
+    @State private var selectedItem = "Medium"
+    let items = ["Small", "Medium", "Large"]
+    Warp.Slider(selectedItem: $selectedItem, items: items)
 ```
 
 ### Legacy support


### PR DESCRIPTION
- add WhatsNew entry
- update `Slider` docs
- add `RangeSlider` docs for iOS
- mark `Broadcast` as deprecated